### PR TITLE
feat: centralize knowledge of more spec elements

### DIFF
--- a/find_project_path.go
+++ b/find_project_path.go
@@ -9,7 +9,8 @@ import (
 
 // FindProjectPath will validate that project path exists and is valid relative to the
 // working directory.
-func FindProjectPath(workingDir, projectPath string) (string, error) {
+func FindProjectPath(workingDir string) (string, error) {
+	projectPath := os.Getenv(ProjectPathEnvName)
 	if projectPath == "" {
 		return workingDir, nil
 	}

--- a/find_project_path_test.go
+++ b/find_project_path_test.go
@@ -20,13 +20,14 @@ func testFindProjectPath(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		workingDir = t.TempDir()
+		t.Setenv("BP_NODE_PROJECT_PATH", "custom/path")
 
 		err := os.MkdirAll(filepath.Join(workingDir, "custom", "path"), os.ModePerm)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	it("returns the project path", func() {
-		result, err := libnodejs.FindProjectPath(workingDir, "custom/path")
+		result, err := libnodejs.FindProjectPath(workingDir)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(filepath.Join(workingDir, "custom", "path")))
 	})
@@ -42,14 +43,18 @@ func testFindProjectPath(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns an error", func() {
-				_, err := libnodejs.FindProjectPath(workingDir, "custom/path")
+				_, err := libnodejs.FindProjectPath(workingDir)
 				Expect(err).To(MatchError(ContainSubstring("permission denied")))
 			})
 		})
 
 		context("when the project path subdirectory does not exist", func() {
+			it.Before(func() {
+				t.Setenv("BP_NODE_PROJECT_PATH", "some-garbage")
+			})
+
 			it("returns an error", func() {
-				_, err := libnodejs.FindProjectPath(workingDir, "some-garbage")
+				_, err := libnodejs.FindProjectPath(workingDir)
 				Expect(err).To(MatchError(ContainSubstring("could not find project path")))
 				Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
 			})

--- a/package_json.go
+++ b/package_json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 // PackageJSON represents the contents of a package.json file.
@@ -17,7 +18,7 @@ type PackageJSON struct {
 
 // ParsePackageJSON parses the contents of a package.json file.
 func ParsePackageJSON(path string) (PackageJSON, error) {
-	file, err := os.Open(path)
+	file, err := os.Open(filepath.Join(path, "package.json"))
 	if err != nil {
 		return PackageJSON{}, err
 	}

--- a/package_json_test.go
+++ b/package_json_test.go
@@ -16,14 +16,16 @@ func testPackageJSON(t *testing.T, context spec.G, it spec.S) {
 
 	var (
 		path       string
+		filePath   string
 		workingDir string
 	)
 
 	it.Before(func() {
 		workingDir = t.TempDir()
 
-		path = filepath.Join(workingDir, "package.json")
-		Expect(os.WriteFile(path, []byte(`{
+		path = workingDir
+		filePath = filepath.Join(workingDir, "package.json")
+		Expect(os.WriteFile(filePath, []byte(`{
 			"scripts": {
 				"poststart": "echo \"poststart\"",
 				"prestart": "echo \"prestart\"",
@@ -46,7 +48,7 @@ func testPackageJSON(t *testing.T, context spec.G, it spec.S) {
 	context("failure cases", func() {
 		context("when the package.json is not a valid json file", func() {
 			it.Before(func() {
-				Expect(os.WriteFile(path, []byte(`%%%`), 0600)).To(Succeed())
+				Expect(os.WriteFile(filePath, []byte(`%%%`), 0600)).To(Succeed())
 			})
 
 			it("fails parsing", func() {
@@ -75,7 +77,7 @@ func testPackageJSON(t *testing.T, context spec.G, it spec.S) {
 
 		context("when a start script is NOT present", func() {
 			it.Before(func() {
-				Expect(os.WriteFile(path, []byte(`{}`), 0600)).To(Succeed())
+				Expect(os.WriteFile(filePath, []byte(`{}`), 0600)).To(Succeed())
 			})
 
 			it("indicates that the package.json file does not have a start script", func() {

--- a/spec_constants.go
+++ b/spec_constants.go
@@ -1,0 +1,3 @@
+package libnodejs
+
+const ProjectPathEnvName = "BP_NODE_PROJECT_PATH"


### PR DESCRIPTION
Centralize knowledge of

- name of package.json
- BP_NODE_PROJECT_PATH environment variable

into libnodejs

Callers of find_project_path should not have to know about BP_NODE_PROJECT_PATH themselves.

Callers of ParsePackageJSON should not have to
add standard `package.json` name to path.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Centralize knowledge of

- name of package.json
- BP_NODE_PROJECT_PATH environment variable

into libnodejs




## Use Cases
Callers of find_project_path should not have to know about BP_NODE_PROJECT_PATH themselves.

Callers of ParsePackageJSON should not have to
add standard `package.json` name to path.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
