### PR TITLE
Add function to get version from package.json

### DIFF
--- a/package_json.go
+++ b/package_json.go
@@ -9,6 +9,9 @@ import (
 
 // PackageJSON represents the contents of a package.json file.
 type PackageJSON struct {
+	Engines struct {
+		Node string `json:"node"`
+	} `json:"engines"`
 	Scripts struct {
 		PostStart string `json:"poststart"`
 		PreStart  string `json:"prestart"`
@@ -37,4 +40,8 @@ func ParsePackageJSON(path string) (PackageJSON, error) {
 // file.
 func (pj PackageJSON) HasStartScript() bool {
 	return pj.Scripts.Start != ""
+}
+
+func (pj PackageJSON) GetVersion() string {
+	return pj.Engines.Node
 }

--- a/package_json_test.go
+++ b/package_json_test.go
@@ -34,6 +34,10 @@ func testPackageJSON(t *testing.T, context spec.G, it spec.S) {
 		}`), 0600)).To(Succeed())
 	})
 
+	it.After(func() {
+		Expect(os.RemoveAll(workingDir)).To(Succeed())
+	})
+
 	context("when parsing a valid package.json with start scripts", func() {
 		it("successfully extracts the scripts information", func() {
 			pkg, err := libnodejs.ParsePackageJSON(path)

--- a/package_json_test.go
+++ b/package_json_test.go
@@ -88,4 +88,50 @@ func testPackageJSON(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 	})
+
+	context("ParseVersion", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filePath, []byte(`{
+				"engines": {
+					"node": "1.2.3"
+				}
+			}`), 0600)).To(Succeed())
+		})
+
+		it("parses the node engine version from a package.json file", func() {
+			pkg, err := libnodejs.ParsePackageJSON(workingDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pkg.GetVersion()).To(Equal("1.2.3"))
+		})
+
+		context("Engines, but no Node version", func() {
+			it.Before(func() {
+				Expect(os.WriteFile(filePath, []byte(`{
+					"engines": {
+					}
+				}`), 0600)).To(Succeed())
+			})
+
+			it("parses the node engine version from a package.json file when no version is specified", func() {
+
+				pkg, err := libnodejs.ParsePackageJSON(workingDir)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pkg.GetVersion()).To(Equal(""))
+			})
+		})
+
+		context("No Engines", func() {
+			it.Before(func() {
+				Expect(os.WriteFile(filePath, []byte(`{
+				}`), 0600)).To(Succeed())
+			})
+
+			it("parses the node engine version from a package.json file when no version is specified", func() {
+
+				pkg, err := libnodejs.ParsePackageJSON(workingDir)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pkg.GetVersion()).To(Equal(""))
+			})
+		})
+	})
 }


### PR DESCRIPTION
package_json_parser needs to parse version to be
re-used in npm-install buildpack.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Add parsing version in package.json helpers so that shared code
can be reused in npm-install

## Use Cases
<!-- An explanation of the use cases your change enables -->
reduce duplicated code and centralize knowledge of constants

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
