### PR TITLE
feat: add support for mjs files when finding apps

### DIFF
--- a/find_node_application.go
+++ b/find_node_application.go
@@ -28,7 +28,8 @@ func FindNodeApplication(workingDir string) (string, error) {
 		return filepath.Clean(launchpoint), nil
 	}
 
-	files := []string{"server.js", "app.js", "main.js", "index.js"}
+	files := []string{"server.js", "server.mjs", "app.js", "app.mjs",
+		"main.js", "main.mjs", "index.js", "index.mjs"}
 	for _, file := range files {
 		_, err := os.Stat(filepath.Join(projectPath, file))
 		if err != nil {

--- a/find_node_application_test.go
+++ b/find_node_application_test.go
@@ -33,6 +33,10 @@ func testFindNodeApplication(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.WriteFile(filepath.Join(workingDir, "app.js"), nil, 0600)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(workingDir, "main.js"), nil, 0600)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(workingDir, "index.js"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "server.mjs"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "app.mjs"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "main.mjs"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "index.mjs"), nil, 0600)).To(Succeed())
 		})
 
 		it("finds the server.js application entrypoint successfully", func() {
@@ -42,11 +46,32 @@ func testFindNodeApplication(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("finds the server.mjs application entrypoint", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filepath.Join(workingDir, "app.js"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "main.js"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "index.js"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "server.mjs"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "app.mjs"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "main.mjs"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "index.mjs"), nil, 0600)).To(Succeed())
+		})
+
+		it("finds the server.js application entrypoint successfully", func() {
+			file, err := libnodejs.FindNodeApplication(workingDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(file).To(Equal(filepath.Join("server.mjs")))
+		})
+	})
+
 	context("finds the app.js application entrypoint", func() {
 		it.Before(func() {
 			Expect(os.WriteFile(filepath.Join(workingDir, "app.js"), nil, 0600)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(workingDir, "main.js"), nil, 0600)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(workingDir, "index.js"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "app.mjs"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "main.mjs"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "index.mjs"), nil, 0600)).To(Succeed())
 		})
 
 		it("finds the app.js application entrypoint successfully", func() {
@@ -56,10 +81,28 @@ func testFindNodeApplication(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("finds the app.mjs application entrypoint", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filepath.Join(workingDir, "main.js"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "index.js"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "app.mjs"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "main.mjs"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "index.mjs"), nil, 0600)).To(Succeed())
+		})
+
+		it("finds the app.js application entrypoint successfully", func() {
+			file, err := libnodejs.FindNodeApplication(workingDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(file).To(Equal(filepath.Join("app.mjs")))
+		})
+	})
+
 	context("finds the main.js application entrypoint", func() {
 		it.Before(func() {
 			Expect(os.WriteFile(filepath.Join(workingDir, "main.js"), nil, 0600)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(workingDir, "index.js"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "main.mjs"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "index.mjs"), nil, 0600)).To(Succeed())
 		})
 
 		it("finds the main.js application entrypoint successfully", func() {
@@ -69,15 +112,42 @@ func testFindNodeApplication(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("finds the main.mjs application entrypoint", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filepath.Join(workingDir, "index.js"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "main.mjs"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "index.mjs"), nil, 0600)).To(Succeed())
+		})
+
+		it("finds the main.js application entrypoint successfully", func() {
+			file, err := libnodejs.FindNodeApplication(workingDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(file).To(Equal(filepath.Join("main.mjs")))
+		})
+	})
+
 	context("finds the index.js application entrypoint", func() {
 		it.Before(func() {
 			Expect(os.WriteFile(filepath.Join(workingDir, "index.js"), nil, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "index.mjs"), nil, 0600)).To(Succeed())
 		})
 
 		it("finds the index.js application entrypoint", func() {
 			file, err := libnodejs.FindNodeApplication(workingDir)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(file).To(Equal(filepath.Join("index.js")))
+		})
+	})
+
+	context("finds the index.mjs application entrypoint", func() {
+		it.Before(func() {
+			Expect(os.WriteFile(filepath.Join(workingDir, "index.mjs"), nil, 0600)).To(Succeed())
+		})
+
+		it("finds the index.js application entrypoint", func() {
+			file, err := libnodejs.FindNodeApplication(workingDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(file).To(Equal(filepath.Join("index.mjs")))
 		})
 	})
 
@@ -132,7 +202,7 @@ func testFindNodeApplication(t *testing.T, context spec.G, it spec.S) {
 	context("when no application can be found", func() {
 		it("returns that application could not be found", func() {
 			_, err := libnodejs.FindNodeApplication(workingDir)
-			Expect(err).To(MatchError(fmt.Errorf("could not find app in %s: expected one of server.js | app.js | main.js | index.js", workingDir)))
+			Expect(err).To(MatchError(fmt.Errorf("could not find app in %s: expected one of server.js | server.mjs | app.js | app.mjs | main.js | main.mjs | index.js | index.mjs", workingDir)))
 		})
 	})
 


### PR DESCRIPTION
Refs: https://github.com/paketo-buildpacks/node-start/issues/225

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Add support for .mjs files when looking for Node.js applications. Node.js added support for mjs a while ago.

## Use Cases
<!-- An explanation of the use cases your change enables -->

An application where the main script file is an `.mjs` file

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
