### PR TITLE
Introduce BP_VERIFY_LAUNCHPOINT to enable generated files

### DIFF
--- a/find_node_application.go
+++ b/find_node_application.go
@@ -17,12 +17,16 @@ func FindNodeApplication(workingDir string) (string, error) {
 
 	launchpoint := os.Getenv(LaunchPointEnvName)
 	if launchpoint != "" {
-		if _, err := os.Stat(filepath.Join(workingDir, launchpoint)); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return "", fmt.Errorf("expected value derived from BP_LAUNCHPOINT [%s] to be an existing file", launchpoint)
-			}
+		doVerify := os.Getenv(VerifyLaunchPointEnvName)
 
-			return "", err
+		if doVerify != "false" {
+			if _, err := os.Stat(filepath.Join(workingDir, launchpoint)); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					return "", fmt.Errorf("expected value derived from BP_LAUNCHPOINT [%s] to be an existing file", launchpoint)
+				}
+
+				return "", err
+			}
 		}
 
 		return filepath.Clean(launchpoint), nil

--- a/find_node_application_test.go
+++ b/find_node_application_test.go
@@ -259,6 +259,22 @@ func testFindNodeApplication(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).To(MatchError(ContainSubstring("expected value derived from BP_LAUNCHPOINT [./no-such-file.js] to be an existing file")))
 				Expect(file).To(Equal(""))
 			})
+
+			it("returns the empty string and no error if BP_VERIFY_LAUNCHPOINT is true", func() {
+				t.Setenv("BP_LAUNCHPOINT", "./no-such-file.js")
+				t.Setenv("BP_VERIFY_LAUNCHPOINT", "true")
+				file, err := libnodejs.FindNodeApplication(workingDir)
+				Expect(err).To(MatchError(ContainSubstring("expected value derived from BP_LAUNCHPOINT [./no-such-file.js] to be an existing file")))
+				Expect(file).To(Equal(""))
+			})
+
+			it("returns the highest priority file if BP_VERIFY_LAUNCHPOINT is false", func() {
+				t.Setenv("BP_LAUNCHPOINT", "./gen/no-such-file-yet.js")
+				t.Setenv("BP_VERIFY_LAUNCHPOINT", "false")
+				file, err := libnodejs.FindNodeApplication(workingDir)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(file).To(Equal(filepath.Join("gen", "no-such-file-yet.js")))
+			})
 		})
 	})
 

--- a/spec_constants.go
+++ b/spec_constants.go
@@ -2,4 +2,5 @@ package libnodejs
 
 const ProjectPathEnvName = "BP_NODE_PROJECT_PATH"
 const LaunchPointEnvName = "BP_LAUNCHPOINT"
+const VerifyLaunchPointEnvName = "BP_VERIFY_LAUNCHPOINT"
 const StartScriptNameEnvName = "BP_NPM_START_SCRIPT"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

see https://github.com/paketo-buildpacks/node-start/issues/588

## Summary
<!-- A short explanation of the proposed change -->

The env variable `BP_VERIFY_LAUNCHPOINT` can be used to not check that the file to launch exists.

## Use Cases
<!-- An explanation of the use cases your change enables -->

If the file that should be launched is generated.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
